### PR TITLE
added some linting and an initial test.. minor fixes + timeout parameter

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
 
-  build:
+  test:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,0 +1,27 @@
+name: Go tests
+
+on:
+  pull_request:
+    branches:
+    - develop
+
+jobs:
+
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Set up Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: 1.18
+
+    - name: Set up gotest CLI
+      run: curl https://gotest-release.s3.amazonaws.com/gotest_linux > gotest && chmod +x gotest
+
+    - name: Build
+      run: go build -v ./...
+
+    - name: Run tests
+      run: ./gotest -v ./...

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -1,0 +1,51 @@
+---
+name: Lint Golang
+
+# See: https://github.com/golangci/golangci-lint-action
+
+on:
+  push:
+    branches:
+    - develop
+    - feature/*
+  pull_request:
+    branches:
+    - develop
+
+permissions:
+  contents: read
+  # Optional: allow read access to pull request. Use with `only-new-issues` option.
+  # pull-requests: read
+jobs:
+  golangci:
+    name: lint
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/setup-go@v3
+      with:
+        go-version: 1.18
+    - uses: actions/checkout@v3
+    - name: golangci-lint
+      uses: golangci/golangci-lint-action@v3
+      with:
+        # Optional: version of golangci-lint to use in form of v1.2 or v1.2.3 or `latest` to use the latest version
+        version: v1.48.0
+
+        # Optional: working directory, useful for monorepos
+        # working-directory: somedir
+
+        # Optional: golangci-lint command line arguments.
+        # args: --issues-exit-code=0
+
+        # Optional: show only new issues if it's a pull request. The default value is `false`.
+        # only-new-issues: true
+
+        # Optional: if set to true then the all caching functionality will be complete disabled,
+        #           takes precedence over all other caching options.
+        # skip-cache: true
+
+        # Optional: if set to true then the action don't cache or restore ~/go/pkg.
+        # skip-pkg-cache: true
+
+        # Optional: if set to true then the action don't cache or restore ~/.cache/go-build.
+        # skip-build-cache: true

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,0 +1,180 @@
+## Golden config for golangci-lint v1.48.0
+#
+run:
+  # Timeout for analysis, e.g. 30s, 5m.
+  # Default: 1m
+  timeout: 3m
+
+
+# This file contains only configs which differ from defaults.
+# All possible options can be found here https://github.com/golangci/golangci-lint/blob/master/.golangci.reference.yml
+linters-settings:
+  cyclop:
+    # The maximal code complexity to report.
+    # Default: 10
+    max-complexity: 30
+    # The maximal average package complexity.
+    # If it's higher than 0.0 (float) the check is enabled
+    # Default: 0.0
+    package-average: 10.0
+
+  errcheck:
+    # Report about not checking of errors in type assertions: `a := b.(MyStruct)`.
+    # Such cases aren't reported by default.
+    # Default: false
+    check-type-assertions: true
+
+  funlen:
+    # Checks the number of lines in a function.
+    # If lower than 0, disable the check.
+    # Default: 60
+    lines: 100
+    # Checks the number of statements in a function.
+    # If lower than 0, disable the check.
+    # Default: 40
+    statements: 50
+
+  gocognit:
+    # Minimal code complexity to report
+    # Default: 30 (but we recommend 10-20)
+    min-complexity: 40
+
+  gocritic:
+    # Settings passed to gocritic.
+    # The settings key is the name of a supported gocritic checker.
+    # The list of supported checkers can be find in https://go-critic.github.io/overview.
+    settings:
+      captLocal:
+        # Whether to restrict checker to params only.
+        # Default: true
+        paramsOnly: false
+      underef:
+        # Whether to skip (*x).method() calls where x is a pointer receiver.
+        # Default: true
+        skipRecvDeref: false
+
+  gomnd:
+    # List of function patterns to exclude from analysis.
+    # Values always ignored: `time.Date`
+    # Default: []
+    ignored-functions:
+      - os.Chmod
+      - os.Mkdir
+      - os.MkdirAll
+      - os.OpenFile
+      - os.WriteFile
+      - prometheus.ExponentialBuckets
+      - prometheus.ExponentialBucketsRange
+      - prometheus.LinearBuckets
+      - strconv.FormatFloat
+      - strconv.FormatInt
+      - strconv.FormatUint
+      - strconv.ParseFloat
+      - strconv.ParseInt
+      - strconv.ParseUint
+
+  nakedret:
+    # Make an issue if func has more lines of code than this setting, and it has naked returns.
+    # Default: 30
+    max-func-lines: 0
+
+  nolintlint:
+    # Exclude following linters from requiring an explanation.
+    # Default: []
+    allow-no-explanation: [ funlen, gocognit, lll ]
+    # Enable to require an explanation of nonzero length after each nolint directive.
+    # Default: false
+    require-explanation: true
+    # Enable to require nolint directives to mention the specific linter being suppressed.
+    # Default: false
+    require-specific: true
+
+  # rowserrcheck:
+  #   # database/sql is always checked
+  #   # Default: []
+  #   packages:
+  #     - github.com/jmoiron/sqlx
+
+  tenv:
+    # The option `all` will run against whole test files (`_test.go`) regardless of method/function signatures.
+    # Otherwise, only methods that take `*testing.T`, `*testing.B`, and `testing.TB` as arguments are checked.
+    # Default: false
+    all: true
+
+  varcheck:
+    # Check usage of exported fields and variables.
+    # Default: false
+    exported-fields: false # default false # TODO: enable after fixing false positives
+
+
+linters:
+  disable-all: true
+  enable:
+    ## enabled by default
+    - deadcode # Finds unused code
+    - errcheck # Errcheck is a program for checking for unchecked errors in go programs. These unchecked errors can be critical bugs in some cases
+    - gosimple # Linter for Go source code that specializes in simplifying a code
+    - govet # Vet examines Go source code and reports suspicious constructs, such as Printf calls whose arguments do not align with the format string
+    - staticcheck # Staticcheck is a go vet on steroids, applying a ton of static analysis checks
+    - typecheck # Like the front-end of a Go compiler, parses and type-checks Go code
+    - unused # Checks Go code for unused constants, variables, functions and types
+    - varcheck # Finds unused global variables and constants
+    - asasalint # Check for pass []any as any in variadic func(...any)
+    - asciicheck # Simple linter to check that your code does not contain non-ASCII identifiers
+    - bidichk # Checks for dangerous unicode character sequences
+    - bodyclose # checks whether HTTP response body is closed successfully
+    - cyclop # checks function and package cyclomatic complexity
+    - dupl # Tool for code clone detection
+    - durationcheck # check for two durations multiplied together
+    - errname # Checks that sentinel errors are prefixed with the Err and error types are suffixed with the Error.
+    - execinquery # execinquery is a linter about query string checker in Query function which reads your Go src files and warning it finds
+    - exhaustive # check exhaustiveness of enum switch statements
+    - exportloopref # checks for pointers to enclosing loop variables
+    - funlen # Tool for detection of long functions
+    - gocognit # Computes and checks the cognitive complexity of functions
+    - goconst # Finds repeated strings that could be replaced by a constant
+    - gocritic # Provides diagnostics that check for bugs, performance and style issues.
+    - gocyclo # Computes and checks the cyclomatic complexity of functions
+    - gomoddirectives # Manage the use of 'replace', 'retract', and 'excludes' directives in go.mod.
+    - gomodguard # Allow and block list linter for direct Go module dependencies. This is different from depguard where there are different block types for example version constraints and module recommendations.
+    - goprintffuncname # Checks that printf-like functions are named with f at the end
+    - makezero # Finds slice declarations with non-zero initial length
+    - nakedret # Finds naked returns in functions greater than a specified function length
+    - nilerr # Finds the code that returns nil even if it checks that the error is not nil.
+    - noctx # noctx finds sending http request without context.Context
+    - nolintlint # Reports ill-formed or insufficient nolint directives
+    - nosprintfhostport # Checks for misuse of Sprintf to construct a host with port in a URL.
+    - predeclared # find code that shadows one of Go's predeclared identifiers
+    - promlinter # Check Prometheus metrics naming via promlint
+    - revive # Fast, configurable, extensible, flexible, and beautiful linter for Go. Drop-in replacement of golint.
+    - stylecheck # Stylecheck is a replacement for golint
+    - tparallel # tparallel detects inappropriate usage of t.Parallel() method in your Go test codes
+    - unconvert # Remove unnecessary type conversions
+    - usestdlibvars # detect the possibility to use variables/constants from the Go standard library
+    - whitespace # Tool for detection of leading and trailing whitespace
+
+
+issues:
+  # Maximum count of issues with the same text.
+  # Set to 0 to disable.
+  # Default: 3
+  max-same-issues: 50
+
+  exclude-rules:
+    - source: "^//\\s*go:generate\\s"
+      linters: [ lll ]
+    - source: "(noinspection|TODO)"
+      linters: [ godot ]
+    - source: "//noinspection"
+      linters: [ gocritic ]
+    - source: "^\\s+if _, ok := err\\.\\([^.]+\\.InternalError\\); ok {"
+      linters: [ errorlint ]
+    - path: "_test\\.go"
+      linters:
+        - bodyclose
+        - dupl
+        - funlen
+        - goconst
+        - gosec
+        - noctx
+        - wrapcheck

--- a/cmd/work.go
+++ b/cmd/work.go
@@ -27,14 +27,14 @@ func init() {
 var workCmd = &cobra.Command{
 	Use:   "work",
 	Short: "do work",
-	Long:  `do work n stuff`,
+	Long:  `do work and stuff`,
 	Run: func(cmd *cobra.Command, args []string) {
 		doWork()
 	},
 }
 
 func doWork() {
-	//logger.Info("doing work for: " + repoURLFlag)
+	// logger.Info("doing work for: " + repoURLFlag)
 	result, err := git.FigureUnixDiskPath(basePath, repoURLFlag)
 	if err != nil {
 		logger.Bad(err)
@@ -45,16 +45,12 @@ func doWork() {
 		return
 	}
 
-	// try to make the dir above (so we can do a clone afterwards)
-
 	splitBySlash := strings.Split(result, "/")
 	slashCount := len(splitBySlash)
 	subDir := strings.Join(splitBySlash[0:slashCount-1], "/")
 	cloneCmd := "git clone --progress " + repoURLFlag
-	//cloneCmd := "git clone -v " + repoURLFlag
 	if directoryExists(subDir) {
 		cmd := fmt.Sprintf("cd %s && %s", subDir, cloneCmd)
-		// logger.Good(fmt.Sprintf("Running 'git clone %s' -> %s", repoURLFlag, result))
 		err := shell.Run(cmd)
 		if err != nil {
 			logger.Bad(err)
@@ -86,14 +82,12 @@ func directoryExists(path string) bool {
 		err := file.Close()
 		if err != nil {
 			logger.Warn(err)
-			//log.Debug(err)
 		}
 	}(file)
 
 	fStat, err := file.Stat()
 	if err != nil {
 		logger.Warn(err)
-		//log.Debug(err)
 		return false
 	}
 	return fStat.IsDir()

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/spf13/cast v1.4.0 // indirect
 	github.com/spf13/cobra v1.2.1
 	github.com/spf13/viper v1.8.1
+	github.com/xhit/go-str2duration/v2 v2.0.0 // indirect
 	golang.org/x/sys v0.0.0-20210630005230-0f9fa26af87c // indirect
 	golang.org/x/text v0.3.6 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -246,6 +246,8 @@ github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5Cc
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/subosito/gotenv v1.2.0 h1:Slr1R9HxAlEKefgq5jn9U+DnETlIUa6HfgEzj0g5d7s=
 github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69rRypqCw=
+github.com/xhit/go-str2duration/v2 v2.0.0 h1:uFtk6FWB375bP7ewQl+/1wBcn840GPhnySOdcz/okPE=
+github.com/xhit/go-str2duration/v2 v2.0.0/go.mod h1:ohY8p+0f07DiV6Em5LKB0s2YpLtXVyJfNt1+BlmyAsU=
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.32/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=

--- a/pkg/git/export_test.go
+++ b/pkg/git/export_test.go
@@ -1,5 +1,5 @@
 package git
 
-func MungeURLForTest(input string) string{
-  return mungeURL(input)
+func Test_mungeURL(input string) {
+	return mungeURL(input)
 }

--- a/pkg/git/export_test.go
+++ b/pkg/git/export_test.go
@@ -1,0 +1,5 @@
+package git
+
+func MungeURLForTest(input string) string{
+  return mungeURL(input)
+}

--- a/pkg/git/git.go
+++ b/pkg/git/git.go
@@ -12,7 +12,6 @@ import (
 )
 
 func FigureUnixDiskPath(localPath string, url string) (string, error) {
-
 	if url == "" {
 		err := errors.New("blank git URL received, please provide a URL argument")
 		return "", err
@@ -22,12 +21,12 @@ func FigureUnixDiskPath(localPath string, url string) (string, error) {
 	if err != nil {
 		logger.Bad(err)
 	}
-	subDir := mungeUrl(url)
+	subDir := mungeURL(url)
 	result := fmt.Sprintf("%s/%s", expandedPath, subDir)
 	return result, nil
 }
 
-func mungeUrl(input string) string {
+func mungeURL(input string) string {
 	rightResult := ""
 	hostname := ""
 	commonPrefixList := []string{

--- a/pkg/git/git_test.go
+++ b/pkg/git/git_test.go
@@ -1,0 +1,57 @@
+package git_test
+
+import (
+	"github.com/starkers/ggg/pkg/git"
+	"reflect"
+	"testing"
+)
+
+func TestSplit(t *testing.T) {
+	tests := []struct {
+		name     string
+		baseDir  string
+		inputURL string
+		want     string
+	}{
+		{name: "githubHttpSimple",
+			baseDir:  "/home/user/src",
+			inputURL: "https://github.com/acmecorp/codebase",
+			want:     "/home/user/src/github.com/acmecorp/codebase"},
+		{name: "githubHttpWithTrailing.git",
+			baseDir:  "/home/user/src",
+			inputURL: "https://github.com/acmecorp/codebase.git",
+			want:     "/home/user/src/github.com/acmecorp/codebase"},
+		{name: "githubGitWithTrailing.git",
+			baseDir:  "/home/user/src",
+			inputURL: "git@github.com:foo/bar.git",
+			want:     "/home/user/src/github.com/foo/bar"},
+		{name: "githubGitWithTrailing.git",
+			baseDir:  "/home/user/src",
+			inputURL: "git@github.com:foo/bar.git",
+			want:     "/home/user/src/github.com/foo/bar"},
+		{name: "gitLabDeep",
+			baseDir:  "/home/user/src",
+			inputURL: "git@gitlab.com:librewolf-community/browser/linux",
+			want:     "/home/user/src/gitlab.com/librewolf-community/browser/linux"},
+		{name: "gitLabDeepWithTrailingGit",
+			baseDir:  "/home/user/src",
+			inputURL: "git@gitlab.com:librewolf-community/browser/linux.git",
+			want:     "/home/user/src/gitlab.com/librewolf-community/browser/linux"},
+		{name: "gitLabDeepHttpSimple",
+			baseDir:  "/home/user/src",
+			inputURL: "https://gitlab.com/librewolf-community/website",
+			want:     "/home/user/src/gitlab.com/librewolf-community/website"},
+		{name: "gitLabDeepHttpWithTrailingGit",
+			baseDir:  "/home/user/src",
+			inputURL: "https://gitlab.com/librewolf-community/website.git",
+			want:     "/home/user/src/gitlab.com/librewolf-community/website"},
+	}
+
+	for _, tc := range tests {
+		got, _ := git.FigureUnixDiskPath(tc.baseDir, tc.inputURL)
+		// TODO: test the errors
+		if !reflect.DeepEqual(tc.want, got) {
+			t.Fatalf("%s: expected: %v, got: %v", tc.name, tc.want, got)
+		}
+	}
+}

--- a/pkg/git/git_test.go
+++ b/pkg/git/git_test.go
@@ -1,12 +1,13 @@
 package git_test
 
 import (
+	"fmt"
 	"github.com/starkers/ggg/pkg/git"
 	"reflect"
 	"testing"
 )
 
-func TestSplit(t *testing.T) {
+func TestFigureUnixDiskPath(t *testing.T) {
 	tests := []struct {
 		name     string
 		baseDir  string
@@ -50,6 +51,25 @@ func TestSplit(t *testing.T) {
 	for _, tc := range tests {
 		got, _ := git.FigureUnixDiskPath(tc.baseDir, tc.inputURL)
 		// TODO: test the errors
+		if !reflect.DeepEqual(tc.want, got) {
+			t.Fatalf("%s: expected: %v, got: %v", tc.name, tc.want, got)
+		}
+	}
+}
+
+func TestMunglURL(t *testing.T) {
+	fmt.Println("asdasd")
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{name: "simple",
+			input: "git@github.com:foo/bar.git",
+			want:  "github.com/foo/bar"},
+	}
+	for _, tc := range tests {
+		got := git.MungeURLForTest(tc.input)
 		if !reflect.DeepEqual(tc.want, got) {
 			t.Fatalf("%s: expected: %v, got: %v", tc.name, tc.want, got)
 		}

--- a/pkg/git/git_test.go
+++ b/pkg/git/git_test.go
@@ -69,7 +69,7 @@ func TestMunglURL(t *testing.T) {
 			want:  "github.com/foo/bar"},
 	}
 	for _, tc := range tests {
-		got := git.MungeURLForTest(tc.input)
+		got := git.Test_mungeURL(tc.input)
 		if !reflect.DeepEqual(tc.want, got) {
 			t.Fatalf("%s: expected: %v, got: %v", tc.name, tc.want, got)
 		}


### PR DESCRIPTION
The first time that someone runs the CLI, some logging is emitted that wasn't safely formatted and results in an error in their shell.. this is not a great first time experience.. it is now fixed

- added some very crude tests to the logic used to convert URLs to their destination disk paths
  - test cases for deeper `site.com/one/two/three/four` levels of paths
  - some test cases for keybase, github and gitlab
  - test cases for converting and handling `.git` at the end of the input paths plus converting `https://` and `git@` URLs
- added a basic `golangci-lint` config
  - added github workflows which will run `golangci-lint`
- added github workflows to run `go test -v ./...`